### PR TITLE
ソースリストのURLを変更

### DIFF
--- a/Dockerfiles/Dockerfile-php71-apache
+++ b/Dockerfiles/Dockerfile-php71-apache
@@ -4,6 +4,8 @@ FROM php:${PHP_VERSION}-apache
 
 ENV APACHE_DOCUMENT_ROOT /var/www/eccube/
 
+RUN sed -i -e 's#deb.debian.org#archive.debian.org#' -e 's#security.debian.org#archive.debian.org#' -e '/stretch-updates/d' /etc/apt/sources.list
+
 RUN apt update && apt install -y --no-install-recommends \
     apt-transport-https \
     apt-utils \

--- a/Dockerfiles/Dockerfile-php72-apache
+++ b/Dockerfiles/Dockerfile-php72-apache
@@ -4,6 +4,8 @@ FROM php:${PHP_VERSION}-apache
 
 ENV APACHE_DOCUMENT_ROOT /var/www/eccube/
 
+RUN sed -i -e 's#deb.debian.org#archive.debian.org#' -e 's#security.debian.org#archive.debian.org#' -e '/stretch-updates/d' /etc/apt/sources.list
+
 RUN apt update && apt install -y --no-install-recommends \
     apt-transport-https \
     apt-utils \


### PR DESCRIPTION
Debian Stretch のサポートが終了したため、パッケージをダウンロードできず、イメージのビルドに失敗します。
解決策として、ソースリストに記載されているURLを、アーカイブのものへ変更します。

PHP7.1の場合のエラーログは以下の通りです。

 => ERROR [2/9] RUN apt update && apt install -y --no-install-recommends     apt-transport-https     apt-utils     0.7s
------
 > [2/9] RUN apt update && apt install -y --no-install-recommends     apt-transport-https     apt-utils     build-essential     curl     debconf-utils     gcc     git     vim     gnupg2     libfreetype6-dev     libicu-dev     libjpeg62-turbo-dev     libpng-dev     libpq-dev     libzip-dev     locales     ssl-cert     unzip     zlib1g-dev     libwebp-dev     && apt clean     && rm -rf /var/lib/apt/lists/*     && echo "en_US.UTF-8 UTF-8" >/etc/locale.gen     && locale-gen     ;:
0.360
0.360 WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
0.360
0.450 Ign:1 http://deb.debian.org/debian buster InRelease
0.452 Ign:2 http://security.debian.org/debian-security buster/updates InRelease
0.463 Ign:3 http://deb.debian.org/debian buster-updates InRelease
0.474 Err:4 http://deb.debian.org/debian buster Release
0.474   404  Not Found [IP: 151.101.130.132 80]
0.488 Err:5 http://deb.debian.org/debian buster-updates Release
0.488   404  Not Found [IP: 151.101.130.132 80]
0.612 Err:6 http://security.debian.org/debian-security buster/updates Release
0.612   404  Not Found [IP: 151.101.130.132 80]
0.620 Reading package lists...
0.628 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
0.628 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
0.628 E: The repository 'http://security.debian.org/debian-security buster/updates Release' does not have a Release file.
